### PR TITLE
Add in-place versions of kron and batched_kron

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Yao = "5872b779-8223-5990-8dd0-5abbb0748c8c"
 [compat]
 BitBasis = "0.6"
 CUDAnative = "2.6, 3.0"
-CuArrays = "1.5, 2.0"
+CuArrays = "1.5, 2.1"
 GPUArrays = "2.0, 3.0"
 LuxurySparse = "0.5, 0.6"
 Reexport = "0.2"

--- a/src/CUDApatch.jl
+++ b/src/CUDApatch.jl
@@ -90,6 +90,12 @@ function kron(A::Union{CuArray{T1}, Adjoint{<:Any, <:CuArray{T1}}}, B::Union{CuA
     res
 end
 
+"""
+    kron!(C::CuArray{T3}, A::Union{CuArray{T1}, Adjoint{<:Any, <:CuArray{T1}}}, B::Union{CuArray{T2}, Adjoint{<:Any, <:CuArray{T2}}}) where {T1 ,T2, T3}
+
+Computes Kronecker products in-place on the GPU.
+The results are stored in 'C', overwriting the existing values of 'C'.
+"""
 function kron!(C::CuArray{T3}, A::Union{CuArray{T1}, Adjoint{<:Any, <:CuArray{T1}}}, B::Union{CuArray{T2}, Adjoint{<:Any, <:CuArray{T2}}}) where {T1, T2, T3}
     CI = Base.CartesianIndices(C)
     @inline function kernel(C, A, B)

--- a/src/CUDApatch.jl
+++ b/src/CUDApatch.jl
@@ -97,6 +97,7 @@ Computes Kronecker products in-place on the GPU.
 The results are stored in 'C', overwriting the existing values of 'C'.
 """
 function kron!(C::CuArray{T3}, A::Union{CuArray{T1}, Adjoint{<:Any, <:CuArray{T1}}}, B::Union{CuArray{T2}, Adjoint{<:Any, <:CuArray{T2}}}) where {T1, T2, T3}
+    @boundscheck (size(C) == (size(A,1)*size(B,1), size(A,2)*size(B,2))) || throw(DimensionMismatch())
     CI = Base.CartesianIndices(C)
     @inline function kernel(C, A, B)
         state = (blockIdx().x-1) * blockDim().x + threadIdx().x

--- a/src/GPUReg.jl
+++ b/src/GPUReg.jl
@@ -126,6 +126,26 @@ function YaoBase.batched_kron(A::Union{CuArray{T1, 3}, Adjoint{<:Any, <:CuArray{
     res
 end
 
+function YaoBase.batched_kron!(C::CuArray{T3, 3}, A::Union{CuArray{T1, 3}, Adjoint{<:Any, <:CuArray{T1, 3}}}, B::Union{CuArray{T2, 3}, Adjoint{<:Any, <:CuArray{T2, 3}}}) where {T1 ,T2, T3}
+    CI = Base.CartesianIndices(C)
+    @inline function kernel(C, A, B)
+        state = (blockIdx().x-1) * blockDim().x + threadIdx().x
+        if state <= length(C)
+            @inbounds i,j,b = CI[state].I
+            i_A = (i-1) ÷ size(B,1) + 1
+            j_A = (j-1) ÷ size(B,2) + 1
+            i_B = (i-1) % size(B,1) + 1
+            j_B = (j-1) % size(B,2) + 1
+            (@inbounds C[state] = A[i_A, j_A, b]*B[i_B, j_B, b])
+        end
+        return
+    end
+
+    X, Y = cudiv(length(C))
+    @cuda threads=X blocks=Y kernel(C, A, B)
+    C
+end
+
 function join(reg1::GPUReg{B}, reg2::GPUReg{B}) where {B}
     s1 = reg1 |> rank3
     s2 = reg2 |> rank3

--- a/src/GPUReg.jl
+++ b/src/GPUReg.jl
@@ -126,6 +126,12 @@ function YaoBase.batched_kron(A::Union{CuArray{T1, 3}, Adjoint{<:Any, <:CuArray{
     res
 end
 
+"""
+    YaoBase.batched_kron!(C::CuArray{T3, 3}, A::Union{CuArray{T1, 3}, Adjoint{<:Any, <:CuArray{T1, 3}}}, B::Union{CuArray{T2, 3}, Adjoint{<:Any, <:CuArray{T2, 3}}}) where {T1 ,T2, T3}
+
+Performs batched Kronecker products in-place on the GPU.
+The results are stored in 'C', overwriting the existing values of 'C'.
+"""
 function YaoBase.batched_kron!(C::CuArray{T3, 3}, A::Union{CuArray{T1, 3}, Adjoint{<:Any, <:CuArray{T1, 3}}}, B::Union{CuArray{T2, 3}, Adjoint{<:Any, <:CuArray{T2, 3}}}) where {T1 ,T2, T3}
     CI = Base.CartesianIndices(C)
     @inline function kernel(C, A, B)

--- a/src/GPUReg.jl
+++ b/src/GPUReg.jl
@@ -133,6 +133,8 @@ Performs batched Kronecker products in-place on the GPU.
 The results are stored in 'C', overwriting the existing values of 'C'.
 """
 function YaoBase.batched_kron!(C::CuArray{T3, 3}, A::Union{CuArray{T1, 3}, Adjoint{<:Any, <:CuArray{T1, 3}}}, B::Union{CuArray{T2, 3}, Adjoint{<:Any, <:CuArray{T2, 3}}}) where {T1 ,T2, T3}
+    @boundscheck (size(C) == (size(A,1)*size(B,1), size(A,2)*size(B,2)), size(A,3)) || throw(DimensionMismatch())
+    @boundscheck (size(A,3) == size(B,3) == size(C,3)) || throw(DimensionMismatch())
     CI = Base.CartesianIndices(C)
     @inline function kernel(C, A, B)
         state = (blockIdx().x-1) * blockDim().x + threadIdx().x

--- a/test/GPUReg.jl
+++ b/test/GPUReg.jl
@@ -105,10 +105,23 @@ end
 @testset "cuda kron getindex" begin
     a = randn(3,4)
     b = randn(4,2)
-    ca, cb = cu(a), cu(b)
+    c = zeros(12,8)
+    ca, cb, cc = cu(a), cu(b), cu(c)
     @test kron(ca, cb) |> Array ≈ kron(a, b)
+    @test kron!(cc, ca, cb) |> Array ≈ kron(a,b)
 
     v = randn(100) |> cu
     inds = [3,5,2,1,7,1]
     @test v[inds] ≈ v[inds |> CuVector]
+end
+
+@testset "cuda batched_kron" begin
+    a = randn(3,4,5)
+    b = randn(4,2,5)
+    c = zeros(12,8,5)
+    ca, cb, cc = cu(a), cu(b), cu(c)
+    kron!(c, a, b)
+    @test batched_kron(ca, cb) |> Array ≈ batched_kron(a, b)
+    @test batched_kron!(cc, ca, cb) |> Array ≈ batched_kron(a,b)
+
 end

--- a/test/GPUReg.jl
+++ b/test/GPUReg.jl
@@ -110,6 +110,9 @@ end
     @test kron(ca, cb) |> Array ≈ kron(a, b)
     @test kron!(cc, ca, cb) |> Array ≈ kron(a,b)
 
+    kron!(c,a,b)
+    @test cc |> Array ≈ c
+
     v = randn(100) |> cu
     inds = [3,5,2,1,7,1]
     @test v[inds] ≈ v[inds |> CuVector]
@@ -120,8 +123,10 @@ end
     b = randn(4,2,5)
     c = zeros(12,8,5)
     ca, cb, cc = cu(a), cu(b), cu(c)
-    kron!(c, a, b)
-    @test batched_kron(ca, cb) |> Array ≈ batched_kron(a, b)
-    @test batched_kron!(cc, ca, cb) |> Array ≈ batched_kron(a,b)
 
+    @test batched_kron(ca, cb) |> Array ≈ batched_kron(a, b)
+    @test batched_kron!(cc, ca, cb) |> Array ≈ batched_kron(a, b)
+
+    batched_kron!(c, a, b)
+    @test cc |> Array ≈ c
 end


### PR DESCRIPTION
Resolves #53 

I started by reusing `kron` and `batched_kron` from this package.


- [x] Check bounds

- [x] Add docstrings

- [x] Add tests

- [ ] (Optional) Benchmarks?

@Roger-luo @GiggleLiu 
What more needs to be done?

