### PR TITLE
Removed unnecessary type parameters and type piracy

### DIFF
--- a/src/instructs.jl
+++ b/src/instructs.jl
@@ -305,7 +305,7 @@ for RG in [:Rx, :Ry, :Rz]
             ::Val{$(QuoteNode(RG))},
             locs::Tuple{Int},
             theta::Number
-        ) where {T, N}
+        ) where {T}
         YaoArrayRegister.instruct!(Val(2), state, Val($(QuoteNode(RG))), locs, (), (), theta)
         return state
     end

--- a/src/register.jl
+++ b/src/register.jl
@@ -290,3 +290,4 @@ measure(
     nshots::Int = 1,
     rng::AbstractRNG = Random.GLOBAL_RNG,
 ) = YaoArrayRegister._measure(rng, basis(reg), Array(reg |> probs), nshots)
+

--- a/src/register.jl
+++ b/src/register.jl
@@ -279,7 +279,7 @@ end
 function YaoBlocks.expect(op::AbstractBlock, dm::CuDensityMatrix{D}) where D
     return tr(apply(ArrayReg{D}(dm.state), op).state)
 end
-function expect(op::Scale, reg::DensityMatrix)
+function expect(op::Scale, reg::CuDensityMatrix)
     factor(op) * expect(content(op), reg)
 end
 

--- a/src/register.jl
+++ b/src/register.jl
@@ -279,9 +279,6 @@ end
 function YaoBlocks.expect(op::AbstractBlock, dm::CuDensityMatrix{D}) where D
     return tr(apply(ArrayReg{D}(dm.state), op).state)
 end
-function expect(op::Scale, reg::CuDensityMatrix)
-    factor(op) * expect(content(op), reg)
-end
 
 measure(
     ::ComputationalBasis,

--- a/test/register.jl
+++ b/test/register.jl
@@ -87,9 +87,9 @@ end
     @test size(res) == (32,)
     @test res2 == res
 
-    reg = repeat(ArrayReg([1,-1+0im]/sqrt(2.0)), 10) |> cu
+    reg = clone(ArrayReg([1,-1+0im]/sqrt(2.0)), 10) |> cu
     @test measure!(X, reg) |> mean ≈ -1
-    reg = repeat(ArrayReg([1.0,0+0im]), 1000)
+    reg = clone(ArrayReg([1.0,0+0im]), 1000)
     @test abs(measure!(X, reg) |> mean) < 0.1
 end
 

--- a/test/register.jl
+++ b/test/register.jl
@@ -136,3 +136,4 @@ end
         @test cpu(reg) ≈ ghz_state(3; nbatch=b) && reg isa AbstractCuArrayReg
     end
 end
+


### PR DESCRIPTION
I got some warnings for the mentioned type parameters and about type piracy that is fixed now.

But since `expect(op::Scale, reg::CuDensityMatrix)` implements exactly the same logic as `expect(op::Scale, reg::DensityMatrix)` in `YaoArrayRegister`, is it even needed or can it be removed altogether?