### PR TITLE
Removed dependence on ExponentialUtilities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CuYao"
 uuid = "b48ca7a8-dd42-11e8-2b8e-1b7706800275"
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
@@ -15,6 +15,7 @@ CUDA = "4, 5"
 Reexport = "0.2, 1"
 TupleTools = "1"
 Yao = "0.8"
+YaoBlocks = "0.13.10"
 julia = "1"
 
 [extras]

--- a/src/CUDApatch.jl
+++ b/src/CUDApatch.jl
@@ -60,5 +60,5 @@ end
 YaoBlocks.AD.as_scalar(x::DenseCuArray) = Array(x)[]
 
 # patch for ExponentialUtilities
-YaoBlocks.ExponentialUtilities.compatible_multiplicative_operand(::CuArray, source::AbstractArray) = CuArray(source)
-YaoBlocks.ExponentialUtilities.compatible_multiplicative_operand(::CuArray, source::CuArray) = source
+YaoBlocks.compatible_multiplicative_operand(::CuArray, source::AbstractArray) = CuArray(source)
+YaoBlocks.compatible_multiplicative_operand(::CuArray, source::CuArray) = source


### PR DESCRIPTION
This should get merged and released after https://github.com/QuantumBFS/Yao.jl/pull/483 is merged so that `TimeEvolve` gates also work with CuArray registers.